### PR TITLE
Add Create to Mini Module

### DIFF
--- a/mod_dpcalendar_mini/tmpl/_scripts.php
+++ b/mod_dpcalendar_mini/tmpl/_scripts.php
@@ -101,6 +101,9 @@ if ($params->get('header_show_navigation', 1)) {
 	$options['headerToolbar']['left'][] = 'prev';
 	$options['headerToolbar']['left'][] = 'next';
 }
+if ($params->get('header_show_create', 1) && \DPCalendar\Helper\DPCalendarHelper::canCreateEvent()) {
+	$options['headerToolbar']['left'][] = 'add';
+}
 if ($params->get('header_show_title', 1)) {
 	$options['headerToolbar']['center'][] = 'title';
 }
@@ -165,6 +168,12 @@ $options['show_map']              = $params->get('show_map', 1);
 $options['event_create_form']     = 0;
 $options['screen_size_list_view'] = 0;
 $options['use_hash']              = false;
+if (\DPCalendar\Helper\DPCalendarHelper::canCreateEvent()) {
+	$router                      = new \DPCalendar\Router\Router();
+	$input                       = JFactory::getApplication()->input;
+	$returnPage                  = $input->getInt('Itemid', null) ? 'index.php?Itemid=' . $input->getInt('Itemid', null) : null;
+	$options['event_create_url'] = $router->getEventFormRoute(0, $returnPage, null, false);
+}
 
 // Set the actual date
 $now              = DPCalendarHelper::getDate($params->get('start_date'));


### PR DESCRIPTION
This PR adds a "Create Event" button the the DPCalendar Mini module if the user is allowed to create events.
![image](https://user-images.githubusercontent.com/1018684/107417236-a6b07700-6b15-11eb-81cc-76229eec25fd.png)

Basically it's copy-pasted code from https://github.com/Digital-Peak/DPCalendar-Free/blob/b71e1d227b227d55bd713339da032d4d811b17cf/com_dpcalendar/site/views/calendar/tmpl/default_options.php#L115-L117 and https://github.com/Digital-Peak/DPCalendar-Free/blob/b71e1d227b227d55bd713339da032d4d811b17cf/com_dpcalendar/site/views/calendar/tmpl/default_options.php#L183-L185 and adjusted to take care of missing `$this->foo` stuff

For me it works, and I hope I followed your codestyle 😄 